### PR TITLE
remove God-forgotten else

### DIFF
--- a/portal-test-win.c
+++ b/portal-test-win.c
@@ -587,7 +587,6 @@ print_done (GtkPrintOperation *op,
       g_signal_connect (error_dialog, "response", G_CALLBACK (gtk_widget_destroy), NULL);
       gtk_widget_show (error_dialog);
     }
-  else
 
   g_free (print_data->text);
   g_free (print_data->font);


### PR DESCRIPTION
Actually it will just do g_free() in else block which we don't want.

Signed-off-by: Igor Gnatenko <ignatenko@src.gnome.org>