### PR TITLE
Small fixes to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The portal interfaces are defined in [xdg-desktop-portal](https://github.com/fla
 
 A GTK+ implementation can be found in [xdg-desktop-portal-gtk](https://github.com/flatpak/xdg-desktop-portal-gtk).
 
-To use this test, use the build script in build/ to produce a flatpak of portal-test, then install it with
+To use this test, use the build script in flatpak/ to produce a flatpak of portal-test, then install it with
 
-    flatpak remote-add --user portal-test file:///path/to/repo
+    flatpak remote-add --user --no-gpg-verify portal-test file:///path/to/repo
     flatpak install --user portal-test org.gnome.PortalTest
 
 and run it with


### PR DESCRIPTION
The command line to add the local repo is missing a parameter, and
the build/ directory is now flatpak/.

Fixes https://github.com/matthiasclasen/portal-test/issues/5