### PR TITLE
Point to the right git repository in the json manifest

### DIFF
--- a/flatpak/org.gnome.PortalTest.json
+++ b/flatpak/org.gnome.PortalTest.json
@@ -34,7 +34,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/matthiasclasen/permission-viewer.git"
+                    "url": "https://github.com/matthiasclasen/portal-test.git"
                 }
             ]
         }


### PR DESCRIPTION
It's currently pointing to something else that's not the portal-test.